### PR TITLE
ClamAV 3.1.2 compatibility

### DIFF
--- a/ClamavSettingsForm.inc.php
+++ b/ClamavSettingsForm.inc.php
@@ -34,7 +34,13 @@ class ClamavSettingsForm extends Form {
 		$this->_contextId = $contextId;
 		$this->_plugin = $plugin;
 
-		parent::__construct($plugin->getTemplatePath() . 'settingsForm.tpl');
+		if (method_exists($plugin, 'getTemplateResource')) {
+			// OJS 3.1.2 and later
+			parent::__construct($plugin->getTemplateResource('settingsForm.tpl'));
+		} else {
+			// OJS 3.1.1 and earlier
+			parent::__construct($plugin->getTemplatePath() . 'settingsForm.tpl');
+		}
 
 		$this->addCheck(new FormValidator($this, 'clamavPath', FORM_VALIDATOR_OPTIONAL_VALUE, 'plugins.generic.clamav.manager.settings.clamavPathRequired'));
 		$this->addCheck(new FormValidatorPost($this));

--- a/version.xml
+++ b/version.xml
@@ -12,8 +12,8 @@
 <version>
 	<application>clamav</application>
 	<type>plugins.generic</type>
-	<release>2.0.0.0</release>
-	<date>2018-09-20</date>
+	<release>2.1.0.0</release>
+	<date>2019-07-03</date>
 	<lazy-load>1</lazy-load>
 	<class>ClamavPlugin</class>
 	<sitewide>1</sitewide>


### PR DESCRIPTION
This should look exceedingly similar to the recent Honeypot changes. Added backwards compatible context helper, replaced context-grabbing code, added version object to plugin object, copied new getTemplatePath method, and updated the form constructor. Tested to work with 3.1.1, 3.1.2, and 3.2.

Does not rework pathing issues identified in issue #1 -- that work will happen separately, after we get this out and start supporting the 3.1.2 release.