### PR TITLE
Warning and code style cleanup

### DIFF
--- a/ClamavPlugin.php
+++ b/ClamavPlugin.php
@@ -190,15 +190,15 @@ class ClamavPlugin extends GenericPlugin {
             $exitCode = '';
             $clamAVPath = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath');
             $scan = exec($clamAVPath . ' --no-summary -i ' . $uploadedFile, $output, $exitCode);
-            //process the result
-            preg_match('/:(.*)/',$output[0],$matches);
-            $virusID=trim($matches[1]);
             switch ($exitCode) {
                 //clean
                 case 0:
                     return false;
                 //virus found!
                 case 1: 
+                    //process the result
+                    preg_match('/:(.*)/',$output[0],$matches);
+                    $virusID=trim($matches[1]);
                     return $virusID;
                 //failed to scan
                 case 2:

--- a/ClamavPlugin.php
+++ b/ClamavPlugin.php
@@ -31,358 +31,353 @@ use APP\template\TemplateManager;
 class ClamScanFailureException extends Exception {};
 
 class ClamavPlugin extends GenericPlugin {
-	const TYPE_SOCKET = 'socket';
-	const TYPE_EXECUTABLE = 'executable';
-	const TIMEOUT_DEFAULT = 30;
-	const UNSCANNED_DEFAULT = 'allow';
-	const UNSCANNED_ALLOW = 'allow';
-	const UNSCANNED_BLOCK = 'block';
+    const TYPE_SOCKET = 'socket';
+    const TYPE_EXECUTABLE = 'executable';
+    const TIMEOUT_DEFAULT = 30;
+    const UNSCANNED_DEFAULT = 'allow';
+    const UNSCANNED_ALLOW = 'allow';
+    const UNSCANNED_BLOCK = 'block';
 
-	/**
-	 * Called as a plugin is registered to the registry
-	 * @param $category String Name of category plugin was registered to
-	 * @return boolean True iff plugin initialized successfully; if false,
-	 * 	the plugin will not be registered.
-	 */
-	function register($category, $path, $mainContextId = NULL) {
-		$success = parent::register($category, $path, $mainContextId);
-		if (!Config::getVar('general', 'installed') || defined('RUNNING_UPGRADE'))
-			return true;
-		if ($success && $this->getEnabled()) {
-			// Enable Clam AV's preprocessing of uploaded files
-			Hook::add('SubmissionFile::validate', array($this, 'clamscanHandleUpload'));
-			// Create handler for AJAX call
-			Hook::add('LoadHandler', array($this, 'setPageHandler'));
-		}
-		return $success;
-	}
+    /**
+     * Called as a plugin is registered to the registry
+     * @param $category String Name of category plugin was registered to
+     * @return boolean True iff plugin initialized successfully; if false,
+     *     the plugin will not be registered.
+     */
+    function register($category, $path, $mainContextId = NULL) {
+        $success = parent::register($category, $path, $mainContextId);
+        if (!Config::getVar('general', 'installed') || defined('RUNNING_UPGRADE'))
+            return true;
+        if ($success && $this->getEnabled()) {
+            // Enable Clam AV's preprocessing of uploaded files
+            Hook::add('SubmissionFile::validate', $this->clamscanHandleUpload(...));
+            // Create handler for AJAX call
+            Hook::add('LoadHandler', $this->setPageHandler(...));
+        }
+        return $success;
+    }
 
-	/**
-	 * Get the display name of this plugin.
-	 * @return String
-	 */
-	function getDisplayName() {
-		return __('plugins.generic.clamav.displayName');
-	}
+    /**
+     * Get the display name of this plugin.
+     * @return String
+     */
+    function getDisplayName() {
+        return __('plugins.generic.clamav.displayName');
+    }
 
-	/**
-	 * Get a description of the plugin.
-	 * @return String
-	 */
-	function getDescription() {
-		return __('plugins.generic.clamav.description');
-	}
+    /**
+     * Get a description of the plugin.
+     * @return String
+     */
+    function getDescription() {
+        return __('plugins.generic.clamav.description');
+    }
 
-	/**
-	 * Site-wide plugins should override this function to return true.
-	 *
-	 * @return boolean
-	 */
-	function isSitePlugin() {
-		return true;
-	}
+    /**
+     * Site-wide plugins should override this function to return true.
+     *
+     * @return boolean
+     */
+    function isSitePlugin() {
+        return true;
+    }
 
-	/**
-	 * @copydoc Plugin::getActions()
-	 */
-	function getActions($request, $verb) {
-		$router = $request->getRouter();
-		return array_merge(
-				$this->getEnabled() ? array(
-			new LinkAction(
-					'settings', new AjaxModal(
-					$router->url($request, null, null, 'manage', null, array('verb' => 'settings', 'plugin' => $this->getName(), 'category' => 'generic')), $this->getDisplayName()
-					), __('manager.plugins.settings'), null
-			),
-				) : array(), parent::getActions($request, $verb)
-		);
-	}
+    /**
+     * @copydoc Plugin::getActions()
+     */
+    function getActions($request, $verb) {
+        $router = $request->getRouter();
+        return array_merge(
+            $this->getEnabled() ? [
+                new LinkAction(
+                    'settings', new AjaxModal(
+                    $router->url($request, null, null, 'manage', null, ['verb' => 'settings', 'plugin' => $this->getName(), 'category' => 'generic']), $this->getDisplayName()
+                    ), __('manager.plugins.settings'), null
+                ),
+            ] : [], parent::getActions($request, $verb)
+        );
+    }
 
-	/**
-	 * @copydoc Plugin::manage()
-	 */
-	function manage($args, $request) {
-		switch ($request->getUserVar('verb')) {
-			case 'settings':
-				$context = Application::get()->getRequest()->getContext();
-				if (!$context) {
-					return false;
-				}
-				$contextID = $context->getId();
+    /**
+     * @copydoc Plugin::manage()
+     */
+    function manage($args, $request) {
+        switch ($request->getUserVar('verb')) {
+            case 'settings':
+                $context = Application::get()->getRequest()->getContext();
+                if (!$context) {
+                    return false;
+                }
+                $contextID = $context->getId();
 
-				$templateMgr = TemplateManager::getManager($request);
-				
-				$templateMgr->registerPlugin('function','plugin_url', array($this, 'smartyPluginUrl'));
+                $templateMgr = TemplateManager::getManager($request);
+                
+                $templateMgr->registerPlugin('function','plugin_url', array($this, 'smartyPluginUrl'));
 
-				$form = new ClamavSettingsForm($this, $contextID);
-				
-				if ($request->getUserVar('save')) {
-					$form->readInputData();
-					if ($form->validate()) {
-						$form->execute();
-						return new JSONMessage(true);
-					}
-				} else {
-					$form->initData($request);
-				}
- 				return new JSONMessage(true, $form->fetch($request));
+                $form = new ClamavSettingsForm($this, $contextID);
+                
+                if ($request->getUserVar('save')) {
+                    $form->readInputData();
+                    if ($form->validate()) {
+                        $form->execute();
+                        return new JSONMessage(true);
+                    }
+                } else {
+                    $form->initData($request);
+                }
+                 return new JSONMessage(true, $form->fetch($request));
 
-			default:
-				assert(false);
-				return false;
-		}
-		return parent::manage($args, $request);
-	}
+            default:
+                assert(false);
+                return false;
+        }
+        return parent::manage($args, $request);
+    }
 
-	/**
-	 * @copydoc PKPPlugin::getTemplatePath
-	 */
-	function getTemplatePath($inCore = false) {
-		return parent::getTemplatePath($inCore);
-	}
+    /**
+     * @copydoc PKPPlugin::getTemplatePath
+     */
+    function getTemplatePath($inCore = false) {
+        return parent::getTemplatePath($inCore);
+    }
 
-	/**
-	 * Get the clam version
-	 * @param $path string Optional path to check. If not provided, the current setting value is used.
-	 * @param $type string Type of connection to be used: executable or socket.
-	 * @return string
-	 * */
-	function getClamVersion($path = '', $type=self::TYPE_EXECUTABLE) {
-		if ($path === '') {
-			$path = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath');
-		}
-		if ($type === self::TYPE_EXECUTABLE && !empty($path) && is_executable($path)) {
-			$version = exec($path . ' --version');
-			if (preg_match('/^ClamAV (.+)/', $version, $matches)) {
-				return $matches[1];
-			}
-		} else if ($type === self::TYPE_SOCKET && !empty($path)) {
-			$output = '';
-			$errno = 0;
-			$errorMessage = "";
-			
-			$clamDaemon = stream_socket_client("$path", $errno, $errorMessage);
+    /**
+     * Get the clam version
+     * @param $path string Optional path to check. If not provided, the current setting value is used.
+     * @param $type string Type of connection to be used: executable or socket.
+     * @return string
+     * */
+    function getClamVersion($path = '', $type=self::TYPE_EXECUTABLE) {
+        if ($path === '') {
+            $path = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath');
+        }
+        if ($type === self::TYPE_EXECUTABLE && !empty($path) && is_executable($path)) {
+            $version = exec($path . ' --version');
+            if (preg_match('/^ClamAV (.+)/', $version, $matches)) {
+                return $matches[1];
+            }
+        } else if ($type === self::TYPE_SOCKET && !empty($path)) {
+            $output = '';
+            $errno = 0;
+            $errorMessage = "";
+            
+            $clamDaemon = stream_socket_client("$path", $errno, $errorMessage);
 
-			if ($clamDaemon) {
-				// clamd wants non-blocking socket connections
-				stream_set_blocking($clamDaemon, false);
+            if ($clamDaemon) {
+                // clamd wants non-blocking socket connections
+                stream_set_blocking($clamDaemon, false);
 
-				// get version of clamd
-				// \0 is null character.
-				stream_socket_sendto($clamDaemon, "zVERSION\0");
-				$output = $this->_clamDaemonShortPolling($clamDaemon);
-				return $output['message'];
-			}
+                // get version of clamd
+                // \0 is null character.
+                stream_socket_sendto($clamDaemon, "zVERSION\0");
+                $output = $this->_clamDaemonShortPolling($clamDaemon);
+                return $output['message'];
+            }
 
-		}
-		return '';
-	}
+        }
+        return '';
+    }
 
-	/**
-	 * Private helper method to scan a file using the clamscan executable, returning a virus message if matched
-	 * @param $uploadedFile string Path to the uploaded file in OJS's files directory
-	 * @throws ClamScanFailureException
-	 * @return boolean|string
-	 */
-	function _clamscanFile($uploadedFile) {
-		if ($this->getClamVersion() && !empty($uploadedFile)) {
-			$output = "";
-			$exitCode = "";
-			$clamAVPath = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath');
-			$scan = exec($clamAVPath . ' --no-summary -i ' . $uploadedFile, $output, $exitCode);
-			//process the result
-			preg_match('/:(.*)/',$output[0],$matches);
-			$virusID=trim($matches[1]);
-			switch ($exitCode) {
-				//clean
-				case 0:
-					return false;
-				//virus found!
-				case 1: 
-					return $virusID;
-				//failed to scan
-				case 2:
-				default:
-			}
-		}
-		throw new ClamScanFailureException("ClamAV failed to scan the file");
-	}
+    /**
+     * Private helper method to scan a file using the clamscan executable, returning a virus message if matched
+     * @param $uploadedFile string Path to the uploaded file in OJS's files directory
+     * @throws ClamScanFailureException
+     * @return boolean|string
+     */
+    function _clamscanFile($uploadedFile) {
+        if ($this->getClamVersion() && !empty($uploadedFile)) {
+            $output = '';
+            $exitCode = '';
+            $clamAVPath = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath');
+            $scan = exec($clamAVPath . ' --no-summary -i ' . $uploadedFile, $output, $exitCode);
+            //process the result
+            preg_match('/:(.*)/',$output[0],$matches);
+            $virusID=trim($matches[1]);
+            switch ($exitCode) {
+                //clean
+                case 0:
+                    return false;
+                //virus found!
+                case 1: 
+                    return $virusID;
+                //failed to scan
+                case 2:
+                default:
+            }
+        }
+        throw new ClamScanFailureException("ClamAV failed to scan the file");
+    }
 
-	/**
-	 * Private helper method to scan a file using the clamav daemon
-	 * @param $uploadedFile string The path to the file to be scanned
-	 * @return boolean|string
-	 */
-	function _clamDaemonFile($uploadedFile) {
-		$clamavSocketPath = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketPath');
-		$maxInstreamSize = 1024; // TODO: need to universalize this based on a plugin setting
-		$output = "";
-		$errno = 0;
-		$errorMessage = "";
+    /**
+     * Private helper method to scan a file using the clamav daemon
+     * @param $uploadedFile string The path to the file to be scanned
+     * @return boolean|string
+     */
+    function _clamDaemonFile($uploadedFile) {
+        $clamavSocketPath = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketPath');
+        $maxInstreamSize = 1024; // TODO: need to universalize this based on a plugin setting
+        $output = '';
+        $errno = 0;
+        $errorMessage = '';
 
-		// stream_socket_client() seems to be preferred over older socket
-		// connections nowadays
-		$clamDaemon = stream_socket_client("$clamavSocketPath", $errno, $errorMessage);
-		// open file for reading in binary mode
-		$tmpFile = fopen($uploadedFile, 'rb');
+        // stream_socket_client() seems to be preferred over older socket
+        // connections nowadays
+        $clamDaemon = stream_socket_client("$clamavSocketPath", $errno, $errorMessage);
+        // open file for reading in binary mode
+        $tmpFile = fopen($uploadedFile, 'rb');
 
-		if ($clamDaemon && $tmpFile) {
-			// clamd wants non-blocking socket connections
-			stream_set_blocking($clamDaemon, false);
+        if ($clamDaemon && $tmpFile) {
+            // clamd wants non-blocking socket connections
+            stream_set_blocking($clamDaemon, false);
 
-			// begin IDSESSION with clamd. z prefix indicates null delimiter.
-			// \0 is null character.
-			stream_socket_sendto($clamDaemon, "zIDSESSION\0");
+            // begin IDSESSION with clamd. z prefix indicates null delimiter.
+            // \0 is null character.
+            stream_socket_sendto($clamDaemon, "zIDSESSION\0");
 
-			/*
-			 * INSTREAM begins data stream for virus scanning. Data is sent
-			 * in chunks, with format <length><data> where <length> is the size
-			 * of the following data in bytes expressed as a 4-byte unsigned
-			 * integer in network byte order.
-			 * 
-			 * We're using pack() to generate the big-endian-formatted numbers.
-			 * 
-			 * As per the clamd man page, clamd requires a non-blocking
-			 * connection which means we need to roll our own polling solution--
-			 * this is managed by _clamDaemonShortPolling().
-			 */
-			stream_socket_sendto($clamDaemon, "zINSTREAM\0");
+            /*
+             * INSTREAM begins data stream for virus scanning. Data is sent
+             * in chunks, with format <length><data> where <length> is the size
+             * of the following data in bytes expressed as a 4-byte unsigned
+             * integer in network byte order.
+             * 
+             * We're using pack() to generate the big-endian-formatted numbers.
+             * 
+             * As per the clamd man page, clamd requires a non-blocking
+             * connection which means we need to roll our own polling solution--
+             * this is managed by _clamDaemonShortPolling().
+             */
+            stream_socket_sendto($clamDaemon, "zINSTREAM\0");
 
-			while (!feof($tmpFile)) {
-				$data = fread($tmpFile, $maxInstreamSize);
-				$package = pack("N", strlen($data)).$data;
-				stream_socket_sendto($clamDaemon, $package);
-			}
-			// terminating INSTREAM with zero-length chunk
-			$data = pack("N", "");
-			stream_socket_sendto($clamDaemon, $data);
+            while (!feof($tmpFile)) {
+                $data = fread($tmpFile, $maxInstreamSize);
+                $package = pack('N', strlen($data)).$data;
+                stream_socket_sendto($clamDaemon, $package);
+            }
+            // terminating INSTREAM with zero-length chunk
+            $data = pack('N', '');
+            stream_socket_sendto($clamDaemon, $data);
 
-			// wait for output
-			$output = $this->_clamDaemonShortPolling($clamDaemon);
+            // wait for output
+            $output = $this->_clamDaemonShortPolling($clamDaemon);
 
-			// closing IDSESSION
-			stream_socket_sendto($clamDaemon, "nEND\0");
+            // closing IDSESSION
+            stream_socket_sendto($clamDaemon, "nEND\0");
 
-			fclose($tmpFile);
-			fclose($clamDaemon);
-			if($output['safe'] === true) {
-				return false;
-			}
-			if($output['safe'] === false) {
-				$msg = trim($output['message']);
-				$msg = preg_replace('/\s*FOUND$/', '', $msg);
-				return $msg;
-			}
-		}
-		throw new ClamScanFailureException("ClamAV Daemon failed to scan the file");
-	}
+            fclose($tmpFile);
+            fclose($clamDaemon);
+            if($output['safe'] === true) {
+                return false;
+            }
+            if($output['safe'] === false) {
+                $msg = trim($output['message']);
+                $msg = preg_replace('/\s*FOUND$/', '', $msg);
+                return $msg;
+            }
+        }
+        throw new ClamScanFailureException("ClamAV Daemon failed to scan the file");
+    }
 
-	/**
-	 * Private helper method to manage short polling a socket and return output
-	 * @param $socket stream resource The streaming socket resource.
-	 * @param $delay int Time between short polls, measured in nanoseconds
-	 * @param $intervals int Number of intervals to check; after $intervals checks, return.
-	 * @throws ClamScanFailureException
-	 * @return string
-	 */
-	function _clamDaemonShortPolling($socket, $delay = 100000000, $intervals = 10) {
-		// author's note: cludge cludge cludge cludge. TODO: look into long polling for unix sockets?
-		$output = "";
-		$intervals = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketTimeout')*10;
-		$failover = $this->getSetting(PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles');
-		
-		for ($i = 0; $i < $intervals; $i++) {
-			// sleep() does not accept fractional seconds and usleep uses a surprising amount of CPU, leaving us with time_nanosleep().
-			time_nanosleep(0, $delay);
-			$output = stream_get_contents($socket);
-			if ($output !== "") {
-				if($output == "1: stream: OK\0") {
-					return Array('safe' => true, 'message' => $output);
-				} else {
-					return Array('safe' => false, 'message' => substr($output, 11));
-				}
-			}
-		}
-		throw new ClamScanFailureException("ClamAV failed to scan the file");
-	}
+    /**
+     * Private helper method to manage short polling a socket and return output
+     * @param $socket stream resource The streaming socket resource.
+     * @param $delay int Time between short polls, measured in nanoseconds
+     * @param $intervals int Number of intervals to check; after $intervals checks, return.
+     * @throws ClamScanFailureException
+     * @return string
+     */
+    function _clamDaemonShortPolling($socket, $delay = 100000000, $intervals = 10) {
+        // author's note: cludge cludge cludge cludge. TODO: look into long polling for unix sockets?
+        $output = '';
+        $intervals = $this->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketTimeout') * 10;
+        $failover = $this->getSetting(PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles');
+        
+        for ($i = 0; $i < $intervals; $i++) {
+            // sleep() does not accept fractional seconds and usleep uses a surprising amount of CPU, leaving us with time_nanosleep().
+            time_nanosleep(0, $delay);
+            $output = stream_get_contents($socket);
+            if ($output !== "") {
+                if($output == "1: stream: OK\0") {
+                    return ['safe' => true, 'message' => $output];
+                } else {
+                    return ['safe' => false, 'message' => substr($output, 11)];
+                }
+            }
+        }
+        throw new ClamScanFailureException("ClamAV failed to scan the file");
+    }
 
-	/**
-	 * Hook callback: scan an uploaded file with ClamAV
-	 * @see \PKP\submissionFile\Repository::validate()
-	 * @param string $hookName
-	 * @param array $args [&$errors, $object, $props, $allowedLocales, $submissionLocale]
-	 *   - $errors array passed by reference; add key/value pairs to block file submission
-	 *   - $props array new/updated properties including fileId
-	 */
+    /**
+     * Hook callback: scan an uploaded file with ClamAV
+     * @see \PKP\submissionFile\Repository::validate()
+     * @param array $args [&$errors, $object, $props, $allowedLocales, $submissionLocale]
+     *   - $errors array passed by reference; add key/value pairs to block file submission
+     *   - $props array new/updated properties including fileId
+     */
 
-	function clamscanHandleUpload($hookName, $args) {
-		$errors =& $args[0];
-		$props  = $args[2];
-		//scan for viruses if file exists
-		$fileId = $props['fileId'] ?? null;
-		if (!$fileId) {
-			return false;
-		}
+    function clamscanHandleUpload(string $hookName, array $args) {
+        $errors =& $args[0];
+        $props  = $args[2];
+        //scan for viruses if file exists
+        $fileId = $props['fileId'] ?? null;
+        if (!$fileId) {
+            return Hook::CONTINUE;
+        }
 
-		$file = app()->get('file')->get($fileId);
-		if (!$file) {
-			return false;
-		}
+        $file = app()->get('file')->get($fileId);
+        if (!$file) {
+            return Hook::CONTINUE;
+        }
 
-		$filesDir = \PKP\config\Config::getVar('files', 'files_dir');
-		$absolutePath = rtrim($filesDir, '/') . '/' . $file->path;
+        $filesDir = Config::getVar('files', 'files_dir');
+        $absolutePath = rtrim($filesDir, '/') . '/' . $file->path;
 
-		if (!file_exists($absolutePath)) {
-			return false;
-		}
-		//If using ClamAV daemon 
-		$useSocket = $this->getSetting(\PKP\core\PKPApplication::CONTEXT_SITE, 'clamavUseSocket');
+        if (!file_exists($absolutePath)) {
+            return Hook::CONTINUE;
+        }
+        //If using ClamAV daemon 
+        $useSocket = $this->getSetting(\PKP\core\PKPApplication::CONTEXT_SITE, 'clamavUseSocket');
 
-		try {
-			if ($useSocket == true) {
-				$virusName = $this->_clamDaemonFile($absolutePath);
-			} else {
-				$virusName = $this->_clamscanFile($absolutePath);
-			}
-		//if scanning fails, set error to block file submission unless the plugin is in permissive mode
-		} catch (ClamScanFailureException  $e) {
-			$allowUnscanned = $this->getSetting(\PKP\core\PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles');
-			if ($allowUnscanned !== self::UNSCANNED_ALLOW) {
-				$errors['file'] = __(
-					'plugins.generic.clamav.error'
-				);
-			}
-			return false;
-		}
-		//If a virus is found, populate Submission::Validate's error array, blocking file submission
-		if ($virusName !== false) {
-			$errors['file'] = __(
-				'plugins.generic.clamav.uploadBlocked',
-				['threatname' => $virusName]
-			);
-			return false;
-		}
+        try {
+            if ($useSocket == true) {
+                $virusName = $this->_clamDaemonFile($absolutePath);
+            } else {
+                $virusName = $this->_clamscanFile($absolutePath);
+            }
+        //if scanning fails, set error to block file submission unless the plugin is in permissive mode
+        } catch (ClamScanFailureException  $e) {
+            $allowUnscanned = $this->getSetting(\PKP\core\PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles');
+            if ($allowUnscanned !== self::UNSCANNED_ALLOW) {
+                $errors['file'] = __(
+                    'plugins.generic.clamav.error'
+                );
+            }
+            return Hook::CONTINUE;
+        }
+        //If a virus is found, populate Submission::Validate's error array, blocking file submission
+        if ($virusName !== false) {
+            $errors['file'] = __(
+                'plugins.generic.clamav.uploadBlocked',
+                ['threatname' => $virusName]
+            );
+            return Hook::CONTINUE;
+        }
 
-		return false;
-	}
+        return Hook::CONTINUE;
+    }
 
-	/**
-	 * Route requests for the clam version to custom page handler
-	 *
-	 * @see PKPPageRouter::route()
-	 * @param $hookName string
-	 * @param $params array
-	 */
-	public function setPageHandler($hookName, $params) {
-		$page = $params[0];
-		$op = $params[1];
-		$handler = $params[3];
-		if ($this->getEnabled() && $page === 'clamav' && $op === 'clamavVersion') {
-			$params[3] = new ClamavVersionHandler();
-			return true;
-		}
-		return false;
-	}
+    /**
+     * Route requests for the clam version to custom page handler
+     * @see PKPPageRouter::route()
+     */
+    public function setPageHandler(string $hookName, array $params) : bool
+    {
+        $page = $params[0];
+        $op = $params[1];
+        $handler = $params[3];
+        if ($this->getEnabled() && $page === 'clamav' && $op === 'clamavVersion') {
+            $params[3] = new ClamavVersionHandler();
+            return Hook::ABORT;
+        }
+        return Hook::CONTINUE;
+    }
 }
-
-?>

--- a/ClamavSettingsForm.php
+++ b/ClamavSettingsForm.php
@@ -24,116 +24,114 @@ use APP\template\TemplateManager;
 
 class ClamavSettingsForm extends Form {
 
-	/** @var int */
-	var $_contextId;
+    /** @var int */
+    var $_contextId;
 
-	/** @var object */
-	var $_plugin;
-	
-	/**
-	 * Constructor
-	 * @param $plugin ClamavSettingsForm
-	 * @param $contextId int
-	 */
-	function __construct($plugin, $contextId) {
-		$this->_contextId = $contextId;
-		$this->_plugin = $plugin;
-		
-		parent::__construct($plugin->getTemplateResource('settingsForm.tpl'));
-		
-		$this->addCheck(new FormValidator($this, 'clamavPath', FormValidator::FORM_VALIDATOR_OPTIONAL_VALUE, 'plugins.generic.clamav.manager.settings.clamavPathRequired'));
-		$this->addCheck(new FormValidatorPost($this));
-		$this->addCheck(new FormValidatorCSRF($this));
-	}
+    /** @var object */
+    var $_plugin;
+    
+    /**
+     * Constructor
+     * @param $plugin ClamavSettingsForm
+     * @param $contextId int
+     */
+    function __construct($plugin, $contextId) {
+        $this->_contextId = $contextId;
+        $this->_plugin = $plugin;
+        
+        parent::__construct($plugin->getTemplateResource('settingsForm.tpl'));
+        
+        $this->addCheck(new FormValidator($this, 'clamavPath', FormValidator::FORM_VALIDATOR_OPTIONAL_VALUE, 'plugins.generic.clamav.manager.settings.clamavPathRequired'));
+        $this->addCheck(new FormValidatorPost($this));
+        $this->addCheck(new FormValidatorCSRF($this));
+    }
 
-	/**
-	 * Initialize form data.
-	 */
-	function initData() {
-		$plugin = $this->_plugin;
-		$request = Application::get()->getRequest();
-		$basePluginUrl = $request->getBaseUrl() . DIRECTORY_SEPARATOR . $plugin->getPluginPath() . DIRECTORY_SEPARATOR;
+    /**
+     * Initialize form data.
+     */
+    function initData() {
+        $plugin = $this->_plugin;
+        $request = Application::get()->getRequest();
+        $basePluginUrl = $request->getBaseUrl() . DIRECTORY_SEPARATOR . $plugin->getPluginPath() . DIRECTORY_SEPARATOR;
 
-		$this->setData('clamavPath', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath'));
-		$this->setData('clamavUseSocket', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavUseSocket'));
-		$this->setData('clamavSocketPath', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketPath'));
-		$this->setData('unscannedFileOption', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles'));
-		$this->setData('clamavSocketTimeout', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketTimeout'));
+        $this->setData('clamavPath', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavPath'));
+        $this->setData('clamavUseSocket', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavUseSocket'));
+        $this->setData('clamavSocketPath', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketPath'));
+        $this->setData('unscannedFileOption', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles'));
+        $this->setData('clamavSocketTimeout', $plugin->getSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketTimeout'));
 
 
-		$this->setData('pluginJavascriptURL', $basePluginUrl . 'js' . DIRECTORY_SEPARATOR);
-		$this->setData('pluginStylesheetURL', $basePluginUrl . 'css' . DIRECTORY_SEPARATOR);
-		$this->setData('pluginLoadingImageURL', $basePluginUrl . 'images' . DIRECTORY_SEPARATOR . "spinner.gif");
-		$this->setData('pluginLoadingImageURL', $basePluginUrl . 'images' . DIRECTORY_SEPARATOR . "spinner.gif");
-		$this->setData('pluginAjaxUrl', $request->getDispatcher()->url($request, PKPApplication::ROUTE_PAGE, null, 'clamav', 'clamavVersion'));
+        $this->setData('pluginJavascriptURL', $basePluginUrl . 'js' . DIRECTORY_SEPARATOR);
+        $this->setData('pluginStylesheetURL', $basePluginUrl . 'css' . DIRECTORY_SEPARATOR);
+        $this->setData('pluginLoadingImageURL', $basePluginUrl . 'images' . DIRECTORY_SEPARATOR . "spinner.gif");
+        $this->setData('pluginLoadingImageURL', $basePluginUrl . 'images' . DIRECTORY_SEPARATOR . "spinner.gif");
+        $this->setData('pluginAjaxUrl', $request->getDispatcher()->url($request, PKPApplication::ROUTE_PAGE, null, 'clamav', 'clamavVersion'));
 
-		$this->setData('baseUrl', $request->getBaseUrl());
-	}
+        $this->setData('baseUrl', $request->getBaseUrl());
+    }
 
-	/**
-	 * Assign form data to user-submitted data.
-	 */
-	function readInputData() {
-		$this->readUserVars(array('clamavPath', 'clamavUseSocket', 'clamavSocketPath', 'clamavSocketTimeout', 'allowUnscannedFiles',));
-	}
+    /**
+     * Assign form data to user-submitted data.
+     */
+    function readInputData() {
+        $this->readUserVars(['clamavPath', 'clamavUseSocket', 'clamavSocketPath', 'clamavSocketTimeout', 'allowUnscannedFiles',]);
+    }
 
-	/**
-	 * Fetch the form.
-	 * @copydoc Form::fetch()
-	 */
-	function fetch($request, $template = NULL, $display = false) {
-		$templateMgr = TemplateManager::getManager($request);
-		$templateMgr->assign('pluginName', $this->_plugin->getName());
+    /**
+     * Fetch the form.
+     * @copydoc Form::fetch()
+     */
+    function fetch($request, $template = NULL, $display = false) {
+        $templateMgr = TemplateManager::getManager($request);
+        $templateMgr->assign('pluginName', $this->_plugin->getName());
 
-		$unscannedFileOptions = array(
-			'allow' => __('plugins.generic.clamav.manager.settings.allowUnscannedFiles.allow'),
-			'block' => __('plugins.generic.clamav.manager.settings.allowUnscannedFiles.block')
-		);
-		$templateMgr->assign('unscannedFileOptions', $unscannedFileOptions);
+        $unscannedFileOptions = [
+            'allow' => __('plugins.generic.clamav.manager.settings.allowUnscannedFiles.allow'),
+            'block' => __('plugins.generic.clamav.manager.settings.allowUnscannedFiles.block')
+        ];
+        $templateMgr->assign('unscannedFileOptions', $unscannedFileOptions);
 
-		return parent::fetch($request);
-	}
+        return parent::fetch($request);
+    }
 
-	/**
-	 * Save settings.
-	 */
-	function execute(...$functionArgs) {
-		// set defaults if we have them. Not using built-in validation because
-		// these fields aren't mandatory.
-		$clamavSocketTimeout = $this->getData('clamavSocketTimeout');
-		if((int) $clamavSocketTimeout < 1) {
-			$clamavSocketTimeout = $this->_plugin::TIMEOUT_DEFAULT;
-		}
-		$allowUnscannedFiles = $this->getData('allowUnscannedFiles');
-		if((string) $allowUnscannedFiles !== $this->_plugin::UNSCANNED_ALLOW && (string) $allowUnscannedFiles !== $this->_plugin::UNSCANNED_BLOCK) {
-			$allowUnscannedFiles = $this->_plugin::UNSCANNED_DEFAULT;
-		}
+    /**
+     * Save settings.
+     */
+    function execute(...$functionArgs) {
+        // set defaults if we have them. Not using built-in validation because
+        // these fields aren't mandatory.
+        $clamavSocketTimeout = $this->getData('clamavSocketTimeout');
+        if((int) $clamavSocketTimeout < 1) {
+            $clamavSocketTimeout = $this->_plugin::TIMEOUT_DEFAULT;
+        }
+        $allowUnscannedFiles = $this->getData('allowUnscannedFiles');
+        if((string) $allowUnscannedFiles !== $this->_plugin::UNSCANNED_ALLOW && (string) $allowUnscannedFiles !== $this->_plugin::UNSCANNED_BLOCK) {
+            $allowUnscannedFiles = $this->_plugin::UNSCANNED_DEFAULT;
+        }
 
-		$this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavPath', $this->getData('clamavPath'), 'string');
-		$this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavUseSocket', $this->getData('clamavUseSocket'), 'bool');
-		$this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketPath', $this->getData('clamavSocketPath'), 'string');
-		$this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketTimeout', $clamavSocketTimeout, 'int');
-		$this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles', $allowUnscannedFiles, 'string');
-	}
+        $this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavPath', $this->getData('clamavPath'), 'string');
+        $this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavUseSocket', $this->getData('clamavUseSocket'), 'bool');
+        $this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketPath', $this->getData('clamavSocketPath'), 'string');
+        $this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'clamavSocketTimeout', $clamavSocketTimeout, 'int');
+        $this->_plugin->updateSetting(PKPApplication::CONTEXT_SITE, 'allowUnscannedFiles', $allowUnscannedFiles, 'string');
+    }
 
-	/**
-	 * Get a version for display from a clamscan path
-	 * @param $path string
-	 * @return string
-	 */
-	function displayVersion($path) {
-		$plugin = $this->_plugin;
-		$useSocket = $plugin->getSetting(\PKP\core\PKPApplication::CONTEXT_SITE, 'clamavUseSocket');
-		$type = $useSocket
-			? \APP\plugins\generic\clamav\ClamavPlugin::TYPE_SOCKET
-			: \APP\plugins\generic\clamav\ClamavPlugin::TYPE_EXECUTABLE;
-		$version = $plugin->getClamVersion($path, $type);
-		if ($version === '') {
-			$version = __('plugins.generic.clamav.manager.settings.noversion');
-		}
-		return $version;
-	}
+    /**
+     * Get a version for display from a clamscan path
+     * @param $path string
+     * @return string
+     */
+    function displayVersion($path) {
+        $plugin = $this->_plugin;
+        $useSocket = $plugin->getSetting(\PKP\core\PKPApplication::CONTEXT_SITE, 'clamavUseSocket');
+        $type = $useSocket
+            ? \APP\plugins\generic\clamav\ClamavPlugin::TYPE_SOCKET
+            : \APP\plugins\generic\clamav\ClamavPlugin::TYPE_EXECUTABLE;
+        $version = $plugin->getClamVersion($path, $type);
+        if ($version === '') {
+            $version = __('plugins.generic.clamav.manager.settings.noversion');
+        }
+        return $version;
+    }
 
 }
-
-?>


### PR DESCRIPTION
The two attached commits...
- Update the code style for OJS 3.5.0 and newer (indentation; array syntax; first-class callables)
- Resolve a warning when clamav gives no output (which is normal for no viruses detected):
   ```
   PHP Warning:  Undefined array key 0 in .../plugins/generic/clamav/ClamavPlugin.php on line 194
   PHP Warning:  Undefined array key 1 in .../plugins/generic/clamav/ClamavPlugin.php on line 195

   ```